### PR TITLE
Normalize names for arguments in Command and Option annotations

### DIFF
--- a/src/main/java/org/iq80/cli/Option.java
+++ b/src/main/java/org/iq80/cli/Option.java
@@ -27,12 +27,12 @@ import static java.lang.annotation.ElementType.FIELD;
 @Target({FIELD})
 public @interface Option
 {
-    String name() default "";
+    String title() default "";
 
     /**
      * An array of allowed command line parameters (e.g. "-n", "--name", etc...).
      */
-    String[] options();
+    String[] name();
 
     /**
      * A description of this option.

--- a/src/main/java/org/iq80/cli/OptionParser.java
+++ b/src/main/java/org/iq80/cli/OptionParser.java
@@ -45,13 +45,13 @@ public class OptionParser
         Preconditions.checkNotNull(typeConverter, "typeConverter is null");
 
         Field field = path.get(path.size() - 1);
-        if (!optionAnnotation.name().isEmpty()) {
-            this.name = optionAnnotation.name();
+        if (!optionAnnotation.title().isEmpty()) {
+            this.name = optionAnnotation.title();
         } else {
             this.name = field.getName();
         }
 
-        this.options = ImmutableList.copyOf(optionAnnotation.options());
+        this.options = ImmutableList.copyOf(optionAnnotation.name());
         this.description = optionAnnotation.description();
 
         if (optionAnnotation.arity() != -1) {

--- a/src/test/java/org/iq80/cli/CommandTest.java
+++ b/src/test/java/org/iq80/cli/CommandTest.java
@@ -297,7 +297,7 @@ public class CommandTest
         @Command(name = "A")
         class A
         {
-            @Option(options = "-long")
+            @Option(name = "-long")
             public long l;
         }
         CommandParser.create(A.class).parse("-lon", "32");

--- a/src/test/java/org/iq80/cli/GalaxyCommandLineParser.java
+++ b/src/test/java/org/iq80/cli/GalaxyCommandLineParser.java
@@ -67,10 +67,10 @@ public class GalaxyCommandLineParser
 
     public static class GlobalOptions
     {
-        @Option(options = "--debug", description = "Enable debug messages")
+        @Option(name = "--debug", description = "Enable debug messages")
         public boolean debug = false;
 
-        @Option(options = "--coordinator", description = "Galaxy coordinator host (overrides GALAXY_COORDINATOR)")
+        @Option(name = "--coordinator", description = "Galaxy coordinator host (overrides GALAXY_COORDINATOR)")
         public String coordinator = Objects.firstNonNull(System.getenv("GALAXY_COORDINATOR"), "http://localhost:64000");
 
         @Override
@@ -87,22 +87,22 @@ public class GalaxyCommandLineParser
 
     public static class SlotFilter
     {
-        @Option(options = {"-b", "--binary"}, description = "Select slots with a given binary")
+        @Option(name = {"-b", "--binary"}, description = "Select slots with a given binary")
         public List<String> binary;
 
-        @Option(options = {"-c", "--config"}, description = "Select slots with a given configuration")
+        @Option(name = {"-c", "--config"}, description = "Select slots with a given configuration")
         public List<String> config;
 
-        @Option(options = {"-i", "--host"}, description = "Select slots on the given host")
+        @Option(name = {"-i", "--host"}, description = "Select slots on the given host")
         public List<String> host;
 
-        @Option(options = {"-I", "--ip"}, description = "Select slots at the given IP address")
+        @Option(name = {"-I", "--ip"}, description = "Select slots at the given IP address")
         public List<String> ip;
 
-        @Option(options = {"-u", "--uuid"}, description = "Select slot with the given UUID")
+        @Option(name = {"-u", "--uuid"}, description = "Select slot with the given UUID")
         public List<String> uuid;
 
-        @Option(options = {"-s", "--state"}, description = "Select 'r{unning}', 's{topped}' or 'unknown' slots")
+        @Option(name = {"-s", "--state"}, description = "Select 'r{unning}', 's{topped}' or 'unknown' slots")
         public List<String> state;
 
         @Override
@@ -145,7 +145,7 @@ public class GalaxyCommandLineParser
     @Command(name = "install", description = "Install software in a new slot")
     public static class InstallCommand
     {
-        @Option(options = {"--count"}, description = "Number of instances to install")
+        @Option(name = {"--count"}, description = "Number of instances to install")
         public int count = 1;
 
         @Options(GLOBAL)
@@ -312,7 +312,7 @@ public class GalaxyCommandLineParser
         @Options
         public final SlotFilter slotFilter = new SlotFilter();
 
-        @Option(options = {"-x", "--ssh-command"}, description = "Command to execute")
+        @Option(name = {"-x", "--ssh-command"}, description = "Command to execute")
         public String sshCommand;
 
         @Arguments(name = "ssh-arg", description = "Ssh command line arguments")
@@ -334,10 +334,10 @@ public class GalaxyCommandLineParser
 
     public static class AgentOptions
     {
-        @Option(options = {"--count"}, description = "Number of agents to provision")
+        @Option(name = {"--count"}, description = "Number of agents to provision")
         public int count = 1;
 
-        @Option(options = {"--availability-zone"}, description = "Availability zone to provision")
+        @Option(name = {"--availability-zone"}, description = "Availability zone to provision")
         public String availabilityZone;
 
         @Override
@@ -362,10 +362,10 @@ public class GalaxyCommandLineParser
         @Options(GROUP)
         AgentOptions agentOptions;
 
-        @Option(options = {"--count"}, description = "Number of agents to provision")
+        @Option(name = {"--count"}, description = "Number of agents to provision")
         public int count = 1;
 
-        @Option(options = {"--availability-zone"}, description = "Availability zone to provision")
+        @Option(name = {"--availability-zone"}, description = "Availability zone to provision")
         public String availabilityZone;
 
         @Arguments(usage = "[<instance-type>]", description = "Instance type to provision")

--- a/src/test/java/org/iq80/cli/Git.java
+++ b/src/test/java/org/iq80/cli/Git.java
@@ -19,7 +19,7 @@ public class Git
 
     public class GitCommand
     {
-        @Option(options = "-v", description = "Verbose mode")
+        @Option(name = "-v", description = "Verbose mode")
         public boolean verbose;
 
         public void execute()
@@ -39,7 +39,7 @@ public class Git
         @Arguments(description = "Patterns of files to be added")
         public List<String> patterns;
 
-        @Option(options = "-i")
+        @Option(name = "-i")
         public boolean interactive;
     }
 

--- a/src/test/java/org/iq80/cli/ParametersDelegateTest.java
+++ b/src/test/java/org/iq80/cli/ParametersDelegateTest.java
@@ -23,9 +23,9 @@ public class ParametersDelegateTest
             public String nonParamString = "a";
         }
 
-        @Option(options = "-a")
+        @Option(name = "-a")
         public boolean isA;
-        @Option(options = {"-b", "--long-b"})
+        @Option(name = {"-b", "--long-b"})
         public String bValue = "";
         @Options
         public EmptyDelegate delegate = new EmptyDelegate();
@@ -48,15 +48,15 @@ public class ParametersDelegateTest
     {
         public static class ComplexDelegate
         {
-            @Option(options = "-c")
+            @Option(name = "-c")
             public boolean isC;
-            @Option(options = {"-d", "--long-d"})
+            @Option(name = {"-d", "--long-d"})
             public Integer d;
         }
 
-        @Option(options = "-a")
+        @Option(name = "-a")
         public boolean isA;
-        @Option(options = {"-b", "--long-b"})
+        @Option(name = {"-b", "--long-b"})
         public String bValue = "";
         @Options
         public ComplexDelegate delegate = new ComplexDelegate();
@@ -82,10 +82,10 @@ public class ParametersDelegateTest
     {
         public static class LeafDelegate
         {
-            @Option(options = "--list")
+            @Option(name = "--list")
             public List<String> list = newArrayList("value1", "value2");
 
-            @Option(options = "--bool")
+            @Option(name = "--bool")
             public boolean bool;
         }
 
@@ -94,23 +94,23 @@ public class ParametersDelegateTest
             @Options
             public LeafDelegate leafDelegate = new LeafDelegate();
 
-            @Option(options = {"-d", "--long-d"})
+            @Option(name = {"-d", "--long-d"})
             public Integer d;
         }
 
         public static class NestedDelegate2
         {
-            @Option(options = "-c")
+            @Option(name = "-c")
             public boolean isC;
 
             @Options
             public NestedDelegate1 nestedDelegate1 = new NestedDelegate1();
         }
 
-        @Option(options = "-a")
+        @Option(name = "-a")
         public boolean isA;
 
-        @Option(options = {"-b", "--long-b"})
+        @Option(name = {"-b", "--long-b"})
         public String bValue = "";
 
         @Options
@@ -137,7 +137,7 @@ public class ParametersDelegateTest
     {
         public static class Delegate
         {
-            @Option(options = "-a")
+            @Option(name = "-a")
             public String a = "b";
         }
 
@@ -181,7 +181,7 @@ public class ParametersDelegateTest
     {
         public static class ComplexDelegate
         {
-            @Option(options = "-a")
+            @Option(name = "-a")
             public boolean a;
         }
 
@@ -204,7 +204,7 @@ public class ParametersDelegateTest
     {
         public static class Delegate
         {
-            @Option(options = "-a")
+            @Option(name = "-a")
             public String a;
         }
 

--- a/src/test/java/org/iq80/cli/args/Args1.java
+++ b/src/test/java/org/iq80/cli/args/Args1.java
@@ -33,27 +33,27 @@ public class Args1
     @Arguments
     public List<String> parameters = Lists.newArrayList();
 
-    @Option(options = {"-log", "-verbose"}, description = "Level of verbosity")
+    @Option(name = {"-log", "-verbose"}, description = "Level of verbosity")
     public Integer verbose = 1;
 
-    @Option(options = "-groups", description = "Comma-separated list of group names to be run")
+    @Option(name = "-groups", description = "Comma-separated list of group names to be run")
     public String groups;
 
-    @Option(options = "-debug", description = "Debug mode")
+    @Option(name = "-debug", description = "Debug mode")
     public boolean debug = false;
 
-    @Option(options = "-long", description = "A long number")
+    @Option(name = "-long", description = "A long number")
     public long l;
 
-    @Option(options = "-double", description = "A double number")
+    @Option(name = "-double", description = "A double number")
     public double doub;
 
-    @Option(options = "-float", description = "A float number")
+    @Option(name = "-float", description = "A float number")
     public float floa;
 
-    @Option(options = "-bigdecimal", description = "A BigDecimal number")
+    @Option(name = "-bigdecimal", description = "A BigDecimal number")
     public BigDecimal bigd;
 
-    @Option(options = "-date", description = "An ISO 8601 formatted date.")
+    @Option(name = "-date", description = "An ISO 8601 formatted date.")
     public Date date;
 }

--- a/src/test/java/org/iq80/cli/args/Args2.java
+++ b/src/test/java/org/iq80/cli/args/Args2.java
@@ -32,15 +32,15 @@ public class Args2
     @Arguments(description = "List of parameters")
     public List<String> parameters = com.google.common.collect.Lists.newArrayList();
 
-    @Option(options = {"-log", "-verbose"}, description = "Level of verbosity")
+    @Option(name = {"-log", "-verbose"}, description = "Level of verbosity")
     public Integer verbose = 1;
 
-    @Option(options = "-groups", description = "Comma-separated list of group names to be run")
+    @Option(name = "-groups", description = "Comma-separated list of group names to be run")
     public String groups;
 
-    @Option(options = "-debug", description = "Debug mode")
+    @Option(name = "-debug", description = "Debug mode")
     public boolean debug = false;
 
-    @Option(options = "-host", description = "The host")
+    @Option(name = "-host", description = "The host")
     public List<String> hosts = newArrayList();
 }

--- a/src/test/java/org/iq80/cli/args/ArgsArityString.java
+++ b/src/test/java/org/iq80/cli/args/ArgsArityString.java
@@ -33,7 +33,7 @@ import java.util.List;
 public class ArgsArityString
 {
 
-    @Option(options = "-pairs", arity = 2, description = "Pairs")
+    @Option(name = "-pairs", arity = 2, description = "Pairs")
     public List<String> pairs;
 
     @Arguments(description = "Rest")

--- a/src/test/java/org/iq80/cli/args/ArgsBooleanArity.java
+++ b/src/test/java/org/iq80/cli/args/ArgsBooleanArity.java
@@ -24,6 +24,6 @@ import org.iq80.cli.Option;
 @Command(name="ArgsBooleanArity")
 public class ArgsBooleanArity
 {
-    @Option(options = "-debug", arity = 1)
+    @Option(name = "-debug", arity = 1)
     public Boolean debug = false;
 }

--- a/src/test/java/org/iq80/cli/args/ArgsBooleanArity0.java
+++ b/src/test/java/org/iq80/cli/args/ArgsBooleanArity0.java
@@ -24,6 +24,6 @@ import org.iq80.cli.Option;
 @Command(name="ArgsBooleanArity0")
 public class ArgsBooleanArity0
 {
-    @Option(options = "-debug", arity = 0)
+    @Option(name = "-debug", arity = 0)
     public Boolean debug = false;
 }

--- a/src/test/java/org/iq80/cli/args/ArgsDefault.java
+++ b/src/test/java/org/iq80/cli/args/ArgsDefault.java
@@ -29,16 +29,16 @@ public class ArgsDefault
     @Arguments
     public List<String> parameters = Lists.newArrayList();
 
-    @Option(options = "-log", description = "Level of verbosity")
+    @Option(name = "-log", description = "Level of verbosity")
     public Integer log = 1;
 
-    @Option(options = "-groups", description = "Comma-separated list of group names to be run")
+    @Option(name = "-groups", description = "Comma-separated list of group names to be run")
     public String groups;
 
-    @Option(options = "-debug", description = "Debug mode")
+    @Option(name = "-debug", description = "Debug mode")
     public boolean debug = false;
 
-    @Option(options = "-level", description = "A long number")
+    @Option(name = "-level", description = "A long number")
     public long level;
 
 }

--- a/src/test/java/org/iq80/cli/args/ArgsEnum.java
+++ b/src/test/java/org/iq80/cli/args/ArgsEnum.java
@@ -35,7 +35,7 @@ public class ArgsEnum
         ONE, TWO, THREE
     }
 
-    @Option(options = "-choice", description = "Choice parameter")
+    @Option(name = "-choice", description = "Choice parameter")
     public ChoiceType choice = ChoiceType.ONE;
 
 }

--- a/src/test/java/org/iq80/cli/args/ArgsInherited.java
+++ b/src/test/java/org/iq80/cli/args/ArgsInherited.java
@@ -25,7 +25,7 @@ import org.iq80.cli.Option;
 public class ArgsInherited extends ArgsDefault
 {
 
-    @Option(options = "-child", description = "Child parameter")
+    @Option(name = "-child", description = "Child parameter")
     public Integer child = 1;
 
 }

--- a/src/test/java/org/iq80/cli/args/ArgsOutOfMemory.java
+++ b/src/test/java/org/iq80/cli/args/ArgsOutOfMemory.java
@@ -6,10 +6,10 @@ import org.iq80.cli.Option;
 @Command(name="ArgsOutOfMemory")
 public class ArgsOutOfMemory
 {
-    @Option(options = {"-p", "--pattern"},
+    @Option(name = {"-p", "--pattern"},
             description = "pattern used by 'tail'. See http://logback.qos.ch/manual/layouts.html#ClassicPatternLayout and http://logback.qos.ch/manual/layouts.html#AccessPatternLayout")
     public String pattern;
 
-    @Option(options = "-q", description = "Filler arg")
+    @Option(name = "-q", description = "Filler arg")
     public String filler;
 }

--- a/src/test/java/org/iq80/cli/args/ArgsPrivate.java
+++ b/src/test/java/org/iq80/cli/args/ArgsPrivate.java
@@ -24,7 +24,7 @@ import org.iq80.cli.Option;
 @Command(name="ArgsPrivate")
 public class ArgsPrivate
 {
-    @Option(options = "-verbose")
+    @Option(name = "-verbose")
     private Integer verbose = 1;
 
     public Integer getVerbose()

--- a/src/test/java/org/iq80/cli/args/Arity1.java
+++ b/src/test/java/org/iq80/cli/args/Arity1.java
@@ -6,6 +6,6 @@ import org.iq80.cli.Option;
 @Command(name="Arity1")
 public class Arity1
 {
-    @Option(arity = 1, options = "-inspect", description = "", required = false)
+    @Option(arity = 1, name = "-inspect", description = "", required = false)
     public boolean inspect;
 }

--- a/src/test/java/org/iq80/cli/args/CommandLineArgs.java
+++ b/src/test/java/org/iq80/cli/args/CommandLineArgs.java
@@ -31,93 +31,93 @@ public class CommandLineArgs
     @Arguments(description = "The XML suite files to run")
     public List<String> suiteFiles = com.google.common.collect.Lists.newArrayList();
 
-    @Option(options = {"-log", "-verbose"}, description = "Level of verbosity")
+    @Option(name = {"-log", "-verbose"}, description = "Level of verbosity")
     public Integer verbose;
 
-    @Option(options = "-groups", description = "Comma-separated list of group names to be run")
+    @Option(name = "-groups", description = "Comma-separated list of group names to be run")
     public String groups;
 
-    @Option(options = "-excludedgroups", description = "Comma-separated list of group names to be " +
+    @Option(name = "-excludedgroups", description = "Comma-separated list of group names to be " +
             "run")
     public String excludedGroups;
 
-    @Option(options = "-d", description = "Output directory")
+    @Option(name = "-d", description = "Output directory")
     public String outputDirectory;
 
-    @Option(options = "-junit", description = "JUnit mode")
+    @Option(name = "-junit", description = "JUnit mode")
     public Boolean junit = Boolean.FALSE;
 
-    @Option(options = "-listener", description = "List of .class files or list of class names" +
+    @Option(name = "-listener", description = "List of .class files or list of class names" +
             " implementing ITestListener or ISuiteListener")
     public String listener;
 
-    @Option(options = "-methodselectors", description = "List of .class files or list of class " +
+    @Option(name = "-methodselectors", description = "List of .class files or list of class " +
             "names implementing IMethodSelector")
     public String methodSelectors;
 
-    @Option(options = "-objectfactory", description = "List of .class files or list of class " +
+    @Option(name = "-objectfactory", description = "List of .class files or list of class " +
             "names implementing ITestRunnerFactory")
     public String objectFactory;
 
-    @Option(options = "-parallel", description = "Parallel mode (methods, tests or classes)")
+    @Option(name = "-parallel", description = "Parallel mode (methods, tests or classes)")
     public String parallelMode;
 
-    @Option(options = "-configfailurepolicy", description = "Configuration failure policy (skip or continue)")
+    @Option(name = "-configfailurepolicy", description = "Configuration failure policy (skip or continue)")
     public String configFailurePolicy;
 
-    @Option(options = "-threadcount", description = "Number of threads to use when running tests " +
+    @Option(name = "-threadcount", description = "Number of threads to use when running tests " +
             "in parallel")
     public Integer threadCount;
 
-    @Option(options = "-dataproviderthreadcount", description = "Number of threads to use when " +
+    @Option(name = "-dataproviderthreadcount", description = "Number of threads to use when " +
             "running data providers")
     public Integer dataProviderThreadCount;
 
-    @Option(options = "-suitename", description = "Default name of test suite, if not specified " +
+    @Option(name = "-suitename", description = "Default name of test suite, if not specified " +
             "in suite definition file or source code")
     public String suiteName;
 
-    @Option(options = "-testname", description = "Default name of test, if not specified in suite" +
+    @Option(name = "-testname", description = "Default name of test, if not specified in suite" +
             "definition file or source code")
     public String testName;
 
-    @Option(options = "-reporter", description = "Extended configuration for custom report listener")
+    @Option(name = "-reporter", description = "Extended configuration for custom report listener")
     public String reporter;
 
     /**
      * Used as map key for the complete list of report listeners provided with the above argument
      */
-    @Option(options = "-reporterslist")
+    @Option(name = "-reporterslist")
     public String reportersList;
 
-    @Option(options = "-usedefaultlisteners", description = "Whether to use the default listeners")
+    @Option(name = "-usedefaultlisteners", description = "Whether to use the default listeners")
     public String useDefaultListeners = "true";
 
-    @Option(options = "-skipfailedinvocationcounts")
+    @Option(name = "-skipfailedinvocationcounts")
     public Boolean skipFailedInvocationCounts;
 
-    @Option(options = "-testclass", description = "The list of test classes")
+    @Option(name = "-testclass", description = "The list of test classes")
     public String testClass;
 
-    @Option(options = "-testnames", description = "The list of test names to run")
+    @Option(name = "-testnames", description = "The list of test names to run")
     public String testNames;
 
-    @Option(options = "-testjar", description = "")
+    @Option(name = "-testjar", description = "")
     public String testJar;
 
-    @Option(options = "-testRunFactory", description = "")
+    @Option(name = "-testRunFactory", description = "")
     public String testRunFactory;
 
-    @Option(options = "-port", description = "The port")
+    @Option(name = "-port", description = "The port")
     public Integer port;
 
-    @Option(options = "-host", description = "The host")
+    @Option(name = "-host", description = "The host")
     public String host;
 
-    @Option(options = "-master", description = "Host where the master is")
+    @Option(name = "-master", description = "Host where the master is")
     public String master;
 
-    @Option(options = "-slave", description = "Host where the slave is")
+    @Option(name = "-slave", description = "Host where the slave is")
     public String slave;
 
 }

--- a/src/test/java/org/iq80/cli/command/CommandAdd.java
+++ b/src/test/java/org/iq80/cli/command/CommandAdd.java
@@ -36,7 +36,7 @@ public class CommandAdd
     @Arguments(description = "Patterns of files to be added")
     public List<String> patterns;
 
-    @Option(options = "-i")
+    @Option(name = "-i")
     public Boolean interactive = false;
 
 }

--- a/src/test/java/org/iq80/cli/command/CommandCommit.java
+++ b/src/test/java/org/iq80/cli/command/CommandCommit.java
@@ -36,9 +36,9 @@ public class CommandCommit
     @Arguments(description = "List of files")
     public List<String> files;
 
-    @Option(options = "--amend", description = "Amend")
+    @Option(name = "--amend", description = "Amend")
     public Boolean amend = false;
 
-    @Option(options = "--author")
+    @Option(name = "--author")
     public String author;
 }

--- a/src/test/java/org/iq80/cli/command/CommandMain.java
+++ b/src/test/java/org/iq80/cli/command/CommandMain.java
@@ -22,6 +22,6 @@ import org.iq80.cli.Option;
 
 public class CommandMain
 {
-    @Option(options = "-v", description = "Verbose mode")
+    @Option(name = "-v", description = "Verbose mode")
     public Boolean verbose = false;
 }


### PR DESCRIPTION
- Change @Option(options=...) to @Option(name=...)
- Change @Option(name=...") to @Option(title=...)

These changes make @Command and @Option more or less match, which
makes them easier to use.
