### PR TITLE
Handle getopt parsing features

### DIFF
--- a/src/main/java/org/iq80/cli/Parser.java
+++ b/src/main/java/org/iq80/cli/Parser.java
@@ -77,47 +77,64 @@ public class Parser
     {
         while (tokens.hasNext()) {
             OptionMetadata option = findOption(allowedOptions, tokens.peek());
+            if (option != null) {
+                tokens.next();
+                state = state.pushContext(Context.OPTION).withOption(option);
+
+                Object value;
+                if (option.getArity() == 0) {
+                    state = state.withOptionValue(option, Boolean.TRUE)
+                            .popContext();
+                }
+                else if (option.getArity() == 1) {
+                    if (tokens.hasNext()) {
+                        value = TypeConverter.newInstance().convert(option.getTitle(), option.getJavaType(), tokens.next());
+                        state = state.withOptionValue(option, value)
+                                .popContext();
+                    }
+                }
+                else if (option.getArity() > 1) {
+                    ImmutableList.Builder<Object> values = ImmutableList.builder();
+
+                    int count = 0;
+                    while (count < option.getArity() && tokens.hasNext()) {
+                        values.add(TypeConverter.newInstance().convert(option.getTitle(), option.getJavaType(), tokens.next()));
+                        ++count;
+                    }
+
+                    if (count == option.getArity()) {
+                        state = state.withOptionValue(option, values.build())
+                                .popContext();
+                    }
+                }
+                else {
+                    throw new UnsupportedOperationException("arity > 1 not yet supported");
+                }
+            }
+
+            // Handle GNU getopt long-form: --option=value
+            if (option == null) {
+                String[] split = tokens.peek().split("=", 2);
+                if (split.length > 1) {
+                    option = findOption(allowedOptions, split[0]);
+                    if (option != null && option.getArity() == 1) {
+                        Object value = TypeConverter.newInstance().convert(option.getTitle(), option.getJavaType(), split[1]);
+                        state = state.withOption(option).withOptionValue(option, value);
+                        tokens.next();
+                    }
+                    else {
+                        option = null;
+                    }
+                }
+            }
+
             if (option == null) {
                 break;
-            }
-
-            tokens.next();
-            state = state.pushContext(Context.OPTION).withOption(option);
-
-            Object value;
-            if (option.getArity() == 0) {
-                state = state.withOptionValue(option, Boolean.TRUE)
-                        .popContext();
-            }
-            else if (option.getArity() == 1) {
-                if (tokens.hasNext()) {
-                    value = TypeConverter.newInstance().convert(option.getTitle(), option.getJavaType(), tokens.next());
-                    state = state.withOptionValue(option, value)
-                            .popContext();
-                }
-            }
-            else if (option.getArity() > 1) {
-                ImmutableList.Builder<Object> values = ImmutableList.builder();
-
-                int count = 0;
-                while (count < option.getArity() && tokens.hasNext()) {
-                    values.add(TypeConverter.newInstance().convert(option.getTitle(), option.getJavaType(), tokens.next()));
-                    ++count;
-                }
-
-                if (count == option.getArity()) {
-                    state = state.withOptionValue(option, values.build())
-                            .popContext();
-                }
-            }
-            else {
-                throw new UnsupportedOperationException("arity > 1 not yet supported");
             }
         }
 
         return state;
     }
-
 
     private ParseState parseArgs(ParseState state, PeekingIterator<String> tokens, ArgumentsMetadata arguments)
     {

--- a/src/test/java/org/iq80/cli/CommandTest.java
+++ b/src/test/java/org/iq80/cli/CommandTest.java
@@ -68,6 +68,22 @@ public class CommandTest
         Assert.assertEquals(args.bigd, new BigDecimal("1.4"));
     }
 
+    public void equalsArgs()
+            throws ParseException
+    {
+        Args1 args = singleCommandParser(Args1.class).parse("Args1",
+                "-debug", "-log=2", "-float=1.2", "-double=1.3", "-bigdecimal=1.4",
+                "-groups=unit", "a", "b", "c");
+
+        Assert.assertTrue(args.debug);
+        Assert.assertEquals(args.verbose.intValue(), 2);
+        Assert.assertEquals(args.groups, "unit");
+        Assert.assertEquals(args.parameters, Arrays.asList("a", "b", "c"));
+        Assert.assertEquals(args.floa, 1.2f, 0.1f);
+        Assert.assertEquals(args.doub, 1.3f, 0.1f);
+        Assert.assertEquals(args.bigd, new BigDecimal("1.4"));
+    }
+
     /**
      * Make sure that if there are args with multiple names (e.g. "-log" and "-verbose"),
      * the usage will only display it once.

--- a/src/test/java/org/iq80/cli/CommandTest.java
+++ b/src/test/java/org/iq80/cli/CommandTest.java
@@ -31,6 +31,7 @@ import org.iq80.cli.args.ArgsMultipleUnparsed;
 import org.iq80.cli.args.ArgsOutOfMemory;
 import org.iq80.cli.args.ArgsPrivate;
 import org.iq80.cli.args.ArgsRequired;
+import org.iq80.cli.args.ArgsSingleChar;
 import org.iq80.cli.args.Arity1;
 import org.iq80.cli.args.OptionsRequired;
 import org.iq80.cli.command.CommandAdd;
@@ -82,6 +83,35 @@ public class CommandTest
         Assert.assertEquals(args.floa, 1.2f, 0.1f);
         Assert.assertEquals(args.doub, 1.3f, 0.1f);
         Assert.assertEquals(args.bigd, new BigDecimal("1.4"));
+    }
+
+    public void classicGetoptArgs()
+            throws ParseException
+    {
+        ArgsSingleChar args = singleCommandParser(ArgsSingleChar.class).parse("ArgsSingleChar",
+                "-lg", "-dsn", "-2f", "-z", "--Dfoo");
+
+        Assert.assertTrue(args.l);
+        Assert.assertTrue(args.g);
+        Assert.assertTrue(args.d);
+        Assert.assertEquals(args.s, "n");
+        Assert.assertFalse(args.n);
+        Assert.assertTrue(args.two);
+        Assert.assertEquals(args.f, "-z");
+        Assert.assertFalse(args.z);
+        Assert.assertEquals(args.dir, null);
+        Assert.assertEquals(args.parameters, Arrays.asList("--Dfoo"));
+    }
+
+    public void classicGetoptFailure()
+            throws ParseException
+    {
+        ArgsSingleChar args = singleCommandParser(ArgsSingleChar.class).parse("ArgsSingleChar",
+                "-lgX");
+
+        Assert.assertFalse(args.l);
+        Assert.assertFalse(args.g);
+        Assert.assertEquals(args.parameters, Arrays.asList("-lgX"));
     }
 
     /**

--- a/src/test/java/org/iq80/cli/args/ArgsSingleChar.java
+++ b/src/test/java/org/iq80/cli/args/ArgsSingleChar.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) 2010 the original author or authors.
+ * See the notice.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.iq80.cli.args;
+
+import com.google.common.collect.Lists;
+import org.iq80.cli.Arguments;
+import org.iq80.cli.Command;
+import org.iq80.cli.Option;
+
+import java.util.List;
+
+@Command(name="ArgsSingleChar")
+public class ArgsSingleChar
+{
+    @Arguments
+    public List<String> parameters = Lists.newArrayList();
+
+    @Option(name = {"-l"}, description = "Long")
+    public boolean l = false;
+
+    @Option(name = "-g", description = "Global")
+    public boolean g = false;
+
+    @Option(name = "-d", description = "Debug mode")
+    public boolean d = false;
+
+    @Option(name = "-s", description = "A string")
+    public String s = null;
+
+    @Option(name = "-n", description = "No action")
+    public boolean n = false;
+
+    @Option(name = "-2", description = "Two")
+    public boolean two = false;
+
+    @Option(name = "-f", description = "A filename")
+    public String f = null;
+
+    @Option(name = "-z", description = "Compress")
+    public boolean z = false;
+
+    @Option(name = "--D", description = "Directory")
+    public String dir;
+}


### PR DESCRIPTION
Handle classic getopt combining of single-character switches.
Handle GNU getopt --argument=value syntax.
