### PR TITLE
Fix classic getopt breakage.

### DIFF
--- a/src/main/java/org/iq80/cli/Parser.java
+++ b/src/main/java/org/iq80/cli/Parser.java
@@ -19,7 +19,7 @@ import static com.google.common.collect.Iterables.find;
 
 public class Parser
 {
-    private static final Pattern GNU_SHORT_OPTIONS_PATTERN = Pattern.compile("-[^-]+");
+    private static final Pattern SHORT_OPTIONS_PATTERN = Pattern.compile("-[^-].*");
     private final GlobalMetadata metadata;
 
     public Parser(GlobalMetadata metadata)
@@ -98,7 +98,7 @@ public class Parser
             }
 
             // Handle classic getopt syntax: -abc
-            nextState = parseShortGnuGetOpt(tokens, state, allowedOptions);
+            nextState = parseClassicGetOpt(tokens, state, allowedOptions);
             if (nextState != null) {
                 state = nextState;
                 continue;
@@ -171,9 +171,9 @@ public class Parser
         return state;
     }
 
-    private ParseState parseShortGnuGetOpt(PeekingIterator<String> tokens, ParseState state, List<OptionMetadata> allowedOptions)
+    private ParseState parseClassicGetOpt(PeekingIterator<String> tokens, ParseState state, List<OptionMetadata> allowedOptions)
     {
-        if (!GNU_SHORT_OPTIONS_PATTERN.matcher(tokens.peek()).matches()) {
+        if (!SHORT_OPTIONS_PATTERN.matcher(tokens.peek()).matches()) {
             return null;
         }
 

--- a/src/test/java/org/iq80/cli/CommandTest.java
+++ b/src/test/java/org/iq80/cli/CommandTest.java
@@ -89,12 +89,13 @@ public class CommandTest
             throws ParseException
     {
         ArgsSingleChar args = singleCommandParser(ArgsSingleChar.class).parse("ArgsSingleChar",
-                "-lg", "-dsn", "-2f", "-z", "--Dfoo");
+                "-lg", "-dsn", "-pa-p", "-2f", "-z", "--Dfoo");
 
         Assert.assertTrue(args.l);
         Assert.assertTrue(args.g);
         Assert.assertTrue(args.d);
         Assert.assertEquals(args.s, "n");
+        Assert.assertEquals(args.p, "a-p");
         Assert.assertFalse(args.n);
         Assert.assertTrue(args.two);
         Assert.assertEquals(args.f, "-z");

--- a/src/test/java/org/iq80/cli/args/ArgsSingleChar.java
+++ b/src/test/java/org/iq80/cli/args/ArgsSingleChar.java
@@ -43,6 +43,9 @@ public class ArgsSingleChar
     @Option(name = "-s", description = "A string")
     public String s = null;
 
+    @Option(name = "-p", description = "A path")
+    public String p = null;
+
     @Option(name = "-n", description = "No action")
     public boolean n = false;
 


### PR DESCRIPTION
The getopt simplification changes broke parsing of classic getopt when the value had a '-' in it.

Also provide better names.
